### PR TITLE
Fix integer nullable cast in protocol serializer

### DIFF
--- a/drift/lib/src/remote/protocol.dart
+++ b/drift/lib/src/remote/protocol.dart
@@ -191,7 +191,7 @@ class DriftProtocol {
               list[0] as int, list.skip(1).toList()));
         }
 
-        final executorId = fullMessage.last as int;
+        final executorId = fullMessage.last as int?;
         return ExecuteBatchedStatement(
             BatchedStatements(sql, args), executorId);
       case _tag_RunTransactionAction:


### PR DESCRIPTION
Hi. I'm using the package `flutter_foreground_task` to generate a background flutter engine attached to an Native Notification. 
I setup the isolates as below(btw i will try to sugest improvements in the documentation for this case).

```dart 

LazyDatabase _openConnection() {
  return LazyDatabase(() async {
    final dbFolder = await getApplicationDocumentsDirectory();
    final file = File(path.join(dbFolder.path, 'dbname.sqlite'));

    final isolate = await DriftIsolate.spawn(
        () => LazyDatabase(() => NativeDatabase(file)));

    IsolateNameServer.registerPortWithName(
      isolate.connectPort,
      DriftDb.databasePortName,
    );

    return DatabaseConnection.delayed(
      DriftIsolate.fromConnectPort(isolate.connectPort).connect(),
    );
  });
}

QueryExecutor? _tryConnectToDriftIsolate() {
  final connectPort =
      IsolateNameServer.lookupPortByName(DriftDb.databasePortName);

  if (connectPort != null) {
    return DatabaseConnection.delayed(
      DriftIsolate.fromConnectPort(
        connectPort,
      ).connect(
        singleClientMode: true,
      ),
    );
  }

  return null;
}


class DriftDb extends _$DriftDb {
  // we tell the database where to store the data with this constructor
  DriftDb([QueryExecutor? executor])
      : super(_tryConnectToDriftIsolate() ?? _openConnection());
}
```
ps: i will improve the lookupPortByName after

I was  getting this error for the cast specific on this line.
Since the class ExecuteBatchedStatement accepts nullable executorId it looks like it should cast to nullable int.

It occours using Isolate from multiple Flutter engines.

